### PR TITLE
flake.nix: add to support easy inclusion to Nix projects

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1681693905,
+        "narHash": "sha256-XdXMvCt+i2ZcmAIPZvu3RUwcdaC9OX7d1WMAJJokzeA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "db34d7561caa508ece0265a56f382c5d3b7a6c1b",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,68 @@
+{
+  description = "Silicon Heaven Application's Flake";
+
+  outputs = {
+    self,
+    flake-utils,
+    nixpkgs,
+  }:
+    with flake-utils.lib;
+    with nixpkgs.lib; let
+      packages = {
+        system,
+        pkgs,
+      }:
+        with pkgs;
+        with qt6Packages; rec {
+          shvapp = stdenv.mkDerivation {
+            name = "shvapp";
+            src = ./.;
+            outputs = ["out" "dev"];
+            buildInputs = [
+              wrapQtAppsHook
+              qtbase
+              qtmqtt
+              qtserialport
+              qtquick3d
+              qtsvg
+              libxkbcommon
+              doctest
+            ];
+            nativeBuildInputs = [
+              cmake
+            ];
+          };
+          default = shvapp;
+
+          qtmqtt = qtModule rec {
+            pname = "qtmqtt";
+            inherit (qtbase) version;
+            src = fetchurl {
+              url = "https://github.com/qt/qtmqtt/archive/refs/tags/v${version}.tar.gz";
+              sha256 = "P2CpIHVx0ya4eJf/UYFEitJEdCa/Qn7PD1CUCmY4TrE=";
+              name = "v${version}.tar.gz";
+            };
+            qtInputs = [qtbase];
+            nativeBuildInputs = [pkg-config];
+          };
+        };
+    in
+      {
+        overlays.default = final: prev:
+          packages {
+            inherit (prev) system;
+            pkgs = prev;
+          };
+      }
+      // eachDefaultSystem (system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        pkgsSelf = self.packages.${system};
+      in {
+        packages = packages {inherit system pkgs;};
+        legacyPackages = pkgs.extend self.overlays.default;
+
+        checks.default = pkgsSelf.default;
+
+        formatter = pkgs.alejandra;
+      });
+}

--- a/nixos/modules/default.nix
+++ b/nixos/modules/default.nix
@@ -1,0 +1,12 @@
+overlay: let
+  modules = {
+    shvbroker = import ./shvbroker.nix;
+  };
+in
+  modules
+  // {
+    default = {
+      imports = builtins.attrValues modules;
+      config.nixpkgs.overlays = [overlay];
+    };
+  }

--- a/nixos/modules/shvbroker.nix
+++ b/nixos/modules/shvbroker.nix
@@ -1,0 +1,92 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cnf = config.services.shvbroker;
+
+  format = pkgs.formats.json {};
+  cponFile = name: data: {
+    inherit name;
+    path = format.generate "shvbroker-${name}" (filterAttrsRecursive (n: v: v != null) data);
+  };
+  confDir = pkgs.linkFarm "shvbroker-confdir" [
+    (cponFile "shvbroker.conf" cnf.config)
+    (cponFile "access.cpon" cnf.access)
+    (cponFile "mounts.cpon" cnf.mounts)
+    (cponFile "roles.cpon" cnf.roles)
+    (cponFile "users.cpon" cnf.users)
+  ];
+in {
+  options = {
+    services.shvbroker = {
+      enable = mkEnableOption (mdDoc ''
+        Enable Silicon Heaven broker service.
+      '');
+      config = mkOption {
+        type = types.submodule {
+          freeformType = format.type;
+        };
+        default = {server = {port = 3755;};};
+        description = mdDoc ''
+          Broker configuration.
+
+          Any valid option can be specified. The documented options are here
+          only for reference and validation of the common values.
+        '';
+      };
+      access = mkOption {
+        type = types.submodule {
+          freeformType = format.type;
+        };
+        default = {};
+        description = mdDoc ''
+          Access configuration.
+        '';
+      };
+      mounts = mkOption {
+        type = types.submodule {
+          freeformType = format.type;
+        };
+        default = {};
+        description = mdDoc ''
+          Mounts configuration.
+        '';
+      };
+      roles = mkOption {
+        type = types.submodule {
+          freeformType = format.type;
+        };
+        default = {};
+        description = mdDoc ''
+          Roles configuration.
+        '';
+      };
+      users = mkOption {
+        type = types.submodule {
+          freeformType = format.type;
+        };
+        default = {};
+        description = mdDoc ''
+          Users configuration.
+        '';
+      };
+      openFirewall = mkEnableOption (mdDoc ''
+        Open the configured port (config.server.port) in Firewall.
+      '');
+    };
+  };
+
+  config = mkIf cnf.enable {
+    systemd.services.shvbroker = {
+      description = "Silicon Heaven Broker";
+      wantedBy = ["multi-user.target"];
+      serviceConfig.ExecStart = "${pkgs.shvapp}/bin/shvbroker --config-dir ${confDir}";
+    };
+    networking.firewall = mkIf cnf.openFirewall {
+      allowedTCPPorts = [cnf.config.server.port];
+    };
+  };
+}

--- a/nixos/tests/default.nix
+++ b/nixos/tests/default.nix
@@ -1,0 +1,23 @@
+lib: pkgs: nixosModules:
+with builtins;
+with lib; let
+  runTest = path: name: let
+    modtest = import path {inherit nixosModules pkgs;};
+  in
+    nixos.runTest (modtest
+      // {
+        name = modtest.name or name;
+        hostPkgs = modtest.hostPkgs or pkgs;
+      });
+in
+  mapAttrs' (
+    name: value: let
+      nname = removeSuffix ".nix" name;
+    in
+      nameValuePair nname (runTest (./. + "/${name}") nname)
+  )
+  (
+    filterAttrs (n: v: v == "regular" && hasSuffix ".nix" n) (
+      readDir ./.
+    )
+  )

--- a/nixos/tests/shvbroker.nix
+++ b/nixos/tests/shvbroker.nix
@@ -1,0 +1,48 @@
+{
+  pkgs,
+  nixosModules,
+  ...
+}: {
+  nodes = {
+    shvbroker = {
+      imports = [nixosModules.default];
+      services.shvbroker = {
+        enable = true;
+        openFirewall = true;
+        roles.admin.weight = 100;
+        access.admin = [
+          {
+            method = "";
+            pathPattern = "**";
+            role = "su";
+          }
+        ];
+        users.admin = {
+          password = {
+            format = "PLAIN";
+            password = "admin!123";
+          };
+          roles = ["admin"];
+        };
+      };
+    };
+    client = {
+      imports = [nixosModules.default];
+      environment.systemPackages = [pkgs.shvapp];
+    };
+  };
+
+  testScript = ''
+    start_all()
+    shvbroker.wait_for_open_port(3755)
+
+    with subtest("List top level nodes"):
+      res = client.succeed(
+        "shvcall --server-host shvbroker"
+        + " --user admin"
+        + " --password 'admin!123'"
+        + " --method ls"
+      )
+      assert '[".broker"]' in res
+  '';
+}


### PR DESCRIPTION
This is not ideal because with never version of Qt6 the `qtmqtt` package here is going to break due to mismatch hash. Another option would be to fail do to mismatch version (which is way more harder to debug). There is just no way to implement it in such a way it is going to work correctly.

Without qtmqtt cmake fails on missing pkg-config file and thus we have to include it. The best solution is to include it in nixpkgs but for some reason it is not tracked on qt mirrors and thus I am not sure if it is going to be accepted by nixpkgs upstream.